### PR TITLE
purge logs after 7 days

### DIFF
--- a/config/user.cnf
+++ b/config/user.cnf
@@ -4,3 +4,6 @@ default-authentication-plugin=mysql_native_password
 
 # Listen on all interfaces
 bind-address=0.0.0.0
+
+# Purge logs
+expire_logs_days=7


### PR DESCRIPTION
## Summary

An accumulation of log files took down the database server after a lot of product import activity. It's unclear why we accumulated so many logs, but they seem to grow exponentially relative to product creation. 500 products led to 40GB of logs being generated. 

My best guess is that our various plugins are all hooking into the lifecycle of a product creation or update and generating more activity which generates more activity. For now we'll reduce log retention from default of 30 days to 7 days and I've increased the size of the disk to 100GB.