### PR TITLE
remove minor version to get docker build working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # You can change this to a newer version of MySQL available at
 # https://hub.docker.com/r/mysql/mysql-server/tags/
-FROM mysql/mysql-server:5.7.24
+FROM mysql/mysql-server:5.7
 
 # Add timezone data
 RUN yum install -y tzdata && \


### PR DESCRIPTION
I was getting:

```
#6 [2/3] RUN yum install -y tzdata &&     yum clean all &&     rm -rf /var/cache/yum
#6 sha256:ad773330932af216d0b026092d11f222560a55f09a5d3c5588707c145e2a16ac
#6 0.509 Loaded plugins: ovl
#6 1.401 http://repo.mysql.com/yum/mysql-5.7-community/docker/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
#6 1.402 Trying other mirror.
#6 1.416
#6 1.416
#6 1.416  One of the configured repositories failed (MySQL 5.7 Server Minimal),
#6 1.416  and yum doesn't have enough cached data to continue. At this point the only
#6 1.416  safe thing yum can do is fail. There are a few ways to work "fix" this:
#6 1.416
#6 1.416      1. Contact the upstream for the repository and get them to fix the problem.
#6 1.416
#6 1.416      2. Reconfigure the baseurl/etc. for the repository, to point to a working
#6 1.416         upstream. This is most often useful if you are using a newer
#6 1.416         distribution release than is supported by the repository (and the
#6 1.416         packages for the previous distribution release still work).
#6 1.416
#6 1.416      3. Run the command with the repository temporarily disabled
#6 1.416             yum --disablerepo=mysql57-server-minimal ...
#6 1.416
#6 1.416      4. Disable the repository permanently, so yum won't use it by default. Yum
#6 1.416         will then just ignore the repository until you permanently enable it
#6 1.416         again or use --enablerepo for temporary usage:
#6 1.416
#6 1.416             yum-config-manager --disable mysql57-server-minimal
#6 1.416         or
#6 1.416             subscription-manager repos --disable=mysql57-server-minimal
#6 1.416
#6 1.416      5. Configure the failing repository to be skipped, if it is unavailable.
#6 1.416         Note that yum will try to contact the repo. when it runs most commands,
#6 1.416         so will have to try and fail each time (and thus. yum will be be much
#6 1.416         slower). If it is a very temporary problem though, this is often a nice
#6 1.416         compromise:
#6 1.416
#6 1.416             yum-config-manager --save --setopt=mysql57-server-minimal.skip_if_unavailable=true
#6 1.416
#6 1.416 failure: repodata/repomd.xml from mysql57-server-minimal: [Errno 256] No more mirrors to try.
#6 1.416 http://repo.mysql.com/yum/mysql-5.7-community/docker/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
#6 ERROR: executor failed running [/bin/sh -c yum install -y tzdata &&     yum clean all &&     rm -rf /var/cache/yum]: exit code: 1

```

But removing the minor version in the `FROM` statement seems to clear this up.