### PR TITLE
Upgrade to 8.0.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@
 FROM mysql/mysql-server:8.0.24
 
 COPY config/user.cnf /etc/mysql/my.cnf
+CMD [ "--disable-log-bin" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # You can change this to a newer version of MySQL available at
 # https://hub.docker.com/r/mysql/mysql-server/tags/
-FROM mysql/mysql-server:8.0.24
+FROM mysql/mysql-server:8.0.28
 
 COPY config/user.cnf /etc/mysql/my.cnf
 CMD [ "--disable-log-bin" ]

--- a/config/user.cnf
+++ b/config/user.cnf
@@ -6,4 +6,4 @@ default-authentication-plugin=mysql_native_password
 bind-address=0.0.0.0
 
 # Disable binary logging
-binlog_expire_logs_seconds=0
+log_bin=OFF

--- a/config/user.cnf
+++ b/config/user.cnf
@@ -4,3 +4,6 @@ default-authentication-plugin=mysql_native_password
 
 # Listen on all interfaces
 bind-address=0.0.0.0
+
+# Purge logs
+expire_logs_days=7

--- a/config/user.cnf
+++ b/config/user.cnf
@@ -5,5 +5,5 @@ default-authentication-plugin=mysql_native_password
 # Listen on all interfaces
 bind-address=0.0.0.0
 
-# Purge logs
-expire_logs_days=7
+# Disable binary logging
+binlog_expire_logs_seconds=0


### PR DESCRIPTION
## Summary

Updates mysql database server to 8.0.28 which may fix an issue with mysqld [using all available memory](https://github.com/docker-library/mysql/issues/579#issuecomment-1018216782) on the server.